### PR TITLE
Install scikit-learn in Getting Started notebook

### DIFF
--- a/titanic/Getting_Started_With_Layer.ipynb
+++ b/titanic/Getting_Started_With_Layer.ipynb
@@ -33,7 +33,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install --upgrade layer-sdk -q"
+    "!pip install --upgrade layer-sdk scikit-learn -q"
    ]
   },
   {


### PR DESCRIPTION
The dependency is required to be able to run through the notebook.